### PR TITLE
Checkers game logic

### DIFF
--- a/src/components/GridBoard.tsx
+++ b/src/components/GridBoard.tsx
@@ -90,8 +90,6 @@ export const GridBoard: FunctionComponent<GridBoardProps> = ({
     />
     {grid.map((cell, i) => {
       const p = indexToPoint(i, gridColumns);
-      const isCellHighlighted =
-        highlightedCells?.findIndex(hc => hc === i) !== -1;
       return (
         <GridBox
           key={i}

--- a/src/components/GridBoard.tsx
+++ b/src/components/GridBoard.tsx
@@ -3,6 +3,10 @@ import { GridBox } from "components/GridBox";
 import { Box } from "components/Box";
 import { indexToPoint } from "utils/GridUtil";
 import { GridBoxIcons } from "models/Game";
+import {
+  GRID_COLUMNS,
+  GRID_CELL_WIDTH
+} from "games/Checkers/constants/GameSettings";
 
 interface GridBoardProps {
   width: number;
@@ -12,18 +16,23 @@ interface GridBoardProps {
   gridColumns: number;
   gridCellWidth: number;
   gridBoxIcons: GridBoxIcons;
+  highlightedCells?: Array<number>;
   onClick?: (e: any) => void;
 }
 
 const CheckerdBoard = ({
   width,
   height,
-  fill
+  fill,
+  highlightedCells
 }: {
   fill: string;
   width: number;
   height: number;
+  highlightedCells: Array<number>;
 }) => {
+  const highlightFill = "lemonchiffon";
+  console.log({ highlightedCells });
   return (
     <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
       <pattern
@@ -44,6 +53,20 @@ const CheckerdBoard = ({
         height="100%"
         fill="url(#pattern-checkers)"
       />
+      {highlightedCells.map(hc => {
+        const p = indexToPoint(hc, GRID_COLUMNS);
+        return (
+          <rect
+            key={`hc-${p.x}-${p.y}`}
+            fill={highlightFill}
+            x={p.x * GRID_CELL_WIDTH}
+            width={GRID_CELL_WIDTH}
+            height={GRID_CELL_WIDTH}
+            y={p.y * GRID_CELL_WIDTH}
+            opacity={0.65}
+          />
+        );
+      })}
     </svg>
   );
 };
@@ -56,12 +79,20 @@ export const GridBoard: FunctionComponent<GridBoardProps> = ({
   gridCellWidth,
   gridColumns,
   gridBoxIcons,
+  highlightedCells = [],
   onClick
 }) => (
   <div style={{ width: width, height: height, position: "relative" }}>
-    <CheckerdBoard fill={fill} width={width} height={height} />
+    <CheckerdBoard
+      fill={fill}
+      width={width}
+      height={height}
+      highlightedCells={highlightedCells}
+    />
     {grid.map((cell, i) => {
       const p = indexToPoint(i, gridColumns);
+      const isCellHighlighted =
+        highlightedCells?.findIndex(hc => hc === i) !== -1;
       return (
         <GridBox
           key={i}

--- a/src/components/GridBoard.tsx
+++ b/src/components/GridBoard.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent } from "react";
 import { GridBox } from "components/GridBox";
 import { Box } from "components/Box";
 import { indexToPoint } from "utils/GridUtil";
+import { GridBoxIcons } from "models/Game";
 
 interface GridBoardProps {
   width: number;
@@ -10,6 +11,7 @@ interface GridBoardProps {
   grid: Array<number>;
   gridColumns: number;
   gridCellWidth: number;
+  gridBoxIcons: GridBoxIcons;
   onClick?: (e: any) => void;
 }
 
@@ -53,6 +55,7 @@ export const GridBoard: FunctionComponent<GridBoardProps> = ({
   grid,
   gridCellWidth,
   gridColumns,
+  gridBoxIcons,
   onClick
 }) => (
   <div style={{ width: width, height: height, position: "relative" }}>
@@ -66,6 +69,7 @@ export const GridBoard: FunctionComponent<GridBoardProps> = ({
           y={p.y}
           team={cell}
           gridCellWidth={gridCellWidth}
+          gridBoxIcons={gridBoxIcons}
         />
       );
     })}

--- a/src/components/GridBoard.tsx
+++ b/src/components/GridBoard.tsx
@@ -32,7 +32,6 @@ const CheckerdBoard = ({
   highlightedCells: Array<number>;
 }) => {
   const highlightFill = "lemonchiffon";
-  console.log({ highlightedCells });
   return (
     <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
       <pattern

--- a/src/components/GridBox.tsx
+++ b/src/components/GridBox.tsx
@@ -1,21 +1,23 @@
-import React, { FunctionComponent } from "react";
+import React, { FunctionComponent, useMemo } from "react";
 import { motion } from "framer-motion";
-import { red, blue } from "@material-ui/core/colors";
-import RadioButtonUncheckedIcon from "@material-ui/icons/RadioButtonUnchecked";
-import CloseIcon from "@material-ui/icons/Close";
+// import RadioButtonUncheckedIcon from "@material-ui/icons/RadioButtonUnchecked";
+// import CloseIcon from "@material-ui/icons/Close";
+import { GridBoxIcons } from "models/Game";
 
 interface GridBoxProps {
   x: number;
   y: number;
   team: number;
   gridCellWidth: number;
+  gridBoxIcons: GridBoxIcons;
 }
 
 export const GridBox: FunctionComponent<GridBoxProps> = ({
   x = 0,
   y = 0,
   team = 0,
-  gridCellWidth
+  gridCellWidth,
+  gridBoxIcons
 }) => {
   const variants = {
     open: {
@@ -31,6 +33,7 @@ export const GridBox: FunctionComponent<GridBoxProps> = ({
       y: gridCellWidth * 0.25
     }
   };
+  const Icon = useMemo(() => gridBoxIcons[team]?.icon, [gridBoxIcons, team]);
   return (
     <motion.svg
       width={gridCellWidth}
@@ -45,8 +48,7 @@ export const GridBox: FunctionComponent<GridBoxProps> = ({
       animate={team >= 0 ? "open" : "closed"}
       variants={variants}
     >
-      {team === 1 && <RadioButtonUncheckedIcon style={{ color: blue[500] }} />}
-      {team === 0 && <CloseIcon style={{ color: red[500] }} />}
+      {Icon && <Icon style={{ color: gridBoxIcons[team].color }} />}
       <rect width={gridCellWidth} height={gridCellWidth} fill="transparent" />
     </motion.svg>
   );

--- a/src/components/GridBox.tsx
+++ b/src/components/GridBox.tsx
@@ -1,7 +1,5 @@
 import React, { FunctionComponent, useMemo } from "react";
 import { motion } from "framer-motion";
-// import RadioButtonUncheckedIcon from "@material-ui/icons/RadioButtonUnchecked";
-// import CloseIcon from "@material-ui/icons/Close";
 import { GridBoxIcons } from "models/Game";
 
 interface GridBoxProps {

--- a/src/games/Checkers/Checkers.tsx
+++ b/src/games/Checkers/Checkers.tsx
@@ -6,6 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import { red, blue } from "@material-ui/core/colors";
 import { GridBoard } from "components/GridBoard";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import RadioButtonUncheckedIcon from "@material-ui/icons/RadioButtonUnchecked";
 import {
   GameStatus,
   allGameFlowDispatches,
@@ -50,7 +51,18 @@ export const Checkers: FunctionComponent<CheckersProps> = ({
     e.persist();
     const x = Math.floor(e.nativeEvent.offsetX / GRID_CELL_WIDTH);
     const y = Math.floor(e.nativeEvent.offsetY / GRID_CELL_WIDTH);
-    dispatch(playerSelectIndex(pointToIndex({ x, y }, GRID_CELL_WIDTH)));
+    dispatch(playerSelectIndex(pointToIndex({ x, y }, GRID_COLUMNS)));
+  };
+
+  const gridBoxIcons = {
+    0: {
+      icon: RadioButtonUncheckedIcon,
+      color: red[500]
+    },
+    1: {
+      icon: RadioButtonUncheckedIcon,
+      color: blue[500]
+    }
   };
 
   return (
@@ -98,6 +110,7 @@ export const Checkers: FunctionComponent<CheckersProps> = ({
           width={GRID_WIDTH}
           height={GRID_WIDTH}
           onClick={handleBoxClick}
+          gridBoxIcons={gridBoxIcons}
         />
       </Grid>
     </Grid>

--- a/src/games/Checkers/Checkers.tsx
+++ b/src/games/Checkers/Checkers.tsx
@@ -53,7 +53,7 @@ export const Checkers: FunctionComponent<CheckersProps> = ({
   const classes = useStyles();
 
   const highlightedCells = [
-    ...(state.possibleMoves || []),
+    ...(state.possibleMoves?.map(pm => pm.index) || []),
     state.selectedCheckerIndex || -1
   ];
 

--- a/src/games/Checkers/Checkers.tsx
+++ b/src/games/Checkers/Checkers.tsx
@@ -13,7 +13,7 @@ import {
   GameState,
   GameAction
 } from "models/Game";
-import { playerSelectIndex } from "games/TicTacToe/hooks/useGameState";
+import { playerSelectIndex } from "games/Checkers/hooks/useGameState";
 import {
   GRID_CELL_WIDTH,
   GRID_COLUMNS,

--- a/src/games/Checkers/Checkers.tsx
+++ b/src/games/Checkers/Checkers.tsx
@@ -54,7 +54,7 @@ export const Checkers: FunctionComponent<CheckersProps> = ({
 
   const highlightedCells = [
     ...(state.possibleMoves?.map(pm => pm.index) || []),
-    state.selectedCheckerIndex || -1
+    state.selectedCheckerIndex !== undefined ? state.selectedCheckerIndex : -1
   ];
 
   const handleBoxClick = (e: React.MouseEvent) => {

--- a/src/games/Checkers/Checkers.tsx
+++ b/src/games/Checkers/Checkers.tsx
@@ -47,6 +47,11 @@ export const Checkers: FunctionComponent<CheckersProps> = ({
 }) => {
   const classes = useStyles();
 
+  const highlightedCells = [
+    ...(state.possibleMoves || []),
+    state.selectedCheckerIndex || -1
+  ];
+
   const handleBoxClick = (e: React.MouseEvent) => {
     e.persist();
     const x = Math.floor(e.nativeEvent.offsetX / GRID_CELL_WIDTH);
@@ -107,6 +112,7 @@ export const Checkers: FunctionComponent<CheckersProps> = ({
           grid={state.grid}
           gridCellWidth={GRID_CELL_WIDTH}
           gridColumns={GRID_COLUMNS}
+          highlightedCells={highlightedCells}
           width={GRID_WIDTH}
           height={GRID_WIDTH}
           onClick={handleBoxClick}

--- a/src/games/Checkers/Checkers.tsx
+++ b/src/games/Checkers/Checkers.tsx
@@ -7,6 +7,7 @@ import { red, blue } from "@material-ui/core/colors";
 import { GridBoard } from "components/GridBoard";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
 import RadioButtonUncheckedIcon from "@material-ui/icons/RadioButtonUnchecked";
+import RadioButtonCheckedIcon from "@material-ui/icons/RadioButtonChecked";
 import {
   GameStatus,
   allGameFlowDispatches,
@@ -17,7 +18,11 @@ import { playerSelectIndex } from "games/Checkers/hooks/useGameState";
 import {
   GRID_CELL_WIDTH,
   GRID_COLUMNS,
-  GRID_WIDTH
+  GRID_WIDTH,
+  TEAM_0,
+  TEAM_0_KING,
+  TEAM_1,
+  TEAM_1_KING
 } from "games/Checkers/constants/GameSettings";
 import { pointToIndex } from "utils/GridUtil";
 
@@ -60,12 +65,20 @@ export const Checkers: FunctionComponent<CheckersProps> = ({
   };
 
   const gridBoxIcons = {
-    0: {
+    [TEAM_0]: {
       icon: RadioButtonUncheckedIcon,
       color: red[500]
     },
-    1: {
+    [TEAM_0_KING]: {
+      icon: RadioButtonCheckedIcon,
+      color: red[500]
+    },
+    [TEAM_1]: {
       icon: RadioButtonUncheckedIcon,
+      color: blue[500]
+    },
+    [TEAM_1_KING]: {
+      icon: RadioButtonCheckedIcon,
       color: blue[500]
     }
   };

--- a/src/games/Checkers/constants/GameSettings.ts
+++ b/src/games/Checkers/constants/GameSettings.ts
@@ -1,4 +1,5 @@
 export const GRID_CELL_WIDTH = 100;
 export const GRID_COLUMNS = 8;
+export const GRID_ROWS = 8;
 export const GRID_WIDTH = GRID_CELL_WIDTH * GRID_COLUMNS;
 export const TEAM_NAMES = ["Red Team", "Blue Team"];

--- a/src/games/Checkers/constants/GameSettings.ts
+++ b/src/games/Checkers/constants/GameSettings.ts
@@ -1,5 +1,12 @@
+// Grid setup
 export const GRID_CELL_WIDTH = 100;
 export const GRID_COLUMNS = 8;
 export const GRID_ROWS = 8;
 export const GRID_WIDTH = GRID_CELL_WIDTH * GRID_COLUMNS;
+
+// Team setup
 export const TEAM_NAMES = ["Red Team", "Blue Team"];
+export const MAX_TEAMS = 2;
+export const EMPTY_CELL = -1;
+export const TEAM_0 = 0;
+export const TEAM_1 = 1;

--- a/src/games/Checkers/constants/GameSettings.ts
+++ b/src/games/Checkers/constants/GameSettings.ts
@@ -9,4 +9,6 @@ export const TEAM_NAMES = ["Red Team", "Blue Team"];
 export const MAX_TEAMS = 2;
 export const EMPTY_CELL = -1;
 export const TEAM_0 = 0;
+export const TEAM_0_KING = TEAM_0 + 0.5;
 export const TEAM_1 = 1;
+export const TEAM_1_KING = TEAM_1 + 0.5;

--- a/src/games/Checkers/hooks/useGameState.ts
+++ b/src/games/Checkers/hooks/useGameState.ts
@@ -15,16 +15,10 @@ import {
   GRID_ROWS,
   EMPTY_CELL,
   TEAM_0,
-  // TEAM_0_KING,
   TEAM_1,
   MAX_TEAMS
 } from "games/Checkers/constants/GameSettings";
-import {
-  indexToPoint,
-  isIndexInMoves,
-  isMoveAJump,
-  getMovesForIndex
-} from "utils/GridUtil";
+import { indexToPoint, getMovesForIndex } from "utils/GridUtil";
 
 /**
  * @param grid Grid to add to
@@ -104,7 +98,6 @@ function onPlayerMessage(
       state.gameStatus === GameStatus.PLAYING &&
       Math.floor(newGrid[payload.index]) === state.currentTeam
     ) {
-      console.log("A");
       const clickedCheckerMoves = getMovesForIndex(
         newGrid,
         payload.index,
@@ -128,15 +121,21 @@ function onPlayerMessage(
       state.gameStatus === GameStatus.PLAYING &&
       newGrid[payload.index] === EMPTY_CELL
     ) {
+      const selectedCheckerIndex =
+        state.selectedCheckerIndex !== undefined
+          ? state.selectedCheckerIndex
+          : -1;
       const moves = getMovesForIndex(
         newGrid,
-        state.selectedCheckerIndex || -1,
-        newGrid[state.selectedCheckerIndex || -1]
+        selectedCheckerIndex,
+        newGrid[selectedCheckerIndex]
       );
       const cellInMoves = moves.find(m => m.index === payload.index);
-
       // Move the selected checker to the clicked cell
-      if (state.selectedCheckerIndex && cellInMoves !== undefined) {
+      if (
+        state.selectedCheckerIndex !== undefined &&
+        cellInMoves !== undefined
+      ) {
         const { isJump, jumpedCellIndex } = cellInMoves;
 
         const py = indexToPoint(payload.index, GRID_COLUMNS).y;
@@ -146,7 +145,7 @@ function onPlayerMessage(
         if (py === 0 || py === GRID_ROWS - 1) {
           newGrid[payload.index] = state.currentTeam + 0.5;
         } else {
-          newGrid[payload.index] = newGrid[state.selectedCheckerIndex || -1];
+          newGrid[payload.index] = newGrid[selectedCheckerIndex];
         }
 
         newGrid[state.selectedCheckerIndex] = EMPTY_CELL;
@@ -179,7 +178,6 @@ function onPlayerMessage(
       }
     }
   }
-
   return state;
 }
 

--- a/src/games/Checkers/hooks/useGameState.ts
+++ b/src/games/Checkers/hooks/useGameState.ts
@@ -190,14 +190,18 @@ function onPlayerMessage(
     state.gameStatus === GameStatus.PLAYING &&
     newGrid[payload.index] === state.currentTeam
   ) {
-    state.selectedCheckerIndex = payload.index;
-    state.possibleMoves = getMovesForIndex(
-      newGrid,
-      payload.index,
-      state.currentTeam
-    );
-    console.log("state.selectedCheckerIndex:: ", state.selectedCheckerIndex);
-    console.log("state.possibleMoves:: ", state.possibleMoves);
+    const m = getMovesForIndex(newGrid, payload.index, state.currentTeam);
+
+    // Highlight selected checker if that checker has moves available
+    if (m.length > 0) {
+      state.selectedCheckerIndex = payload.index;
+      state.possibleMoves = m;
+    }
+    // Else, clear checker/move previews
+    else {
+      state.selectedCheckerIndex = -1;
+      state.possibleMoves = [];
+    }
   }
 
   if (
@@ -211,13 +215,15 @@ function onPlayerMessage(
       payload.index,
       state.currentTeam
     );
-    if (activeCheckerIndex !== -1) {
-      if (activeCheckerIndex !== -1) {
-        newGrid[activeCheckerIndex] = EMPTY_CELL;
-        newGrid[payload.index] = state.currentTeam;
-
-        state.grid = newGrid;
-      }
+    const isCellInPossibleMoves =
+      payload.index &&
+      state.possibleMoves?.findIndex(pm => pm === payload.index) !== -1;
+    if (isCellInPossibleMoves) {
+      newGrid[activeCheckerIndex] = EMPTY_CELL;
+      newGrid[payload.index] = state.currentTeam;
+      state.grid = newGrid;
+      state.selectedCheckerIndex = -1;
+      state.possibleMoves = [];
 
       // did player win
       if (isGameWon(state.grid, state.currentTeam)) {
@@ -253,6 +259,8 @@ function onPlayerMessage(
         newGrid[jumpedCheckerIndex] = EMPTY_CELL;
         newGrid[payload.index] = state.currentTeam;
         state.grid = newGrid;
+        state.selectedCheckerIndex = -1;
+        state.possibleMoves = [];
 
         // did player win
         if (isGameWon(state.grid, state.currentTeam)) {

--- a/src/games/Checkers/hooks/useGameState.ts
+++ b/src/games/Checkers/hooks/useGameState.ts
@@ -110,8 +110,6 @@ function onPlayerMessage(
         state.currentTeam
       );
 
-      console.log({ clickedCheckerMoves, payload });
-
       // Highlight selected checker if that checker has moves available
       if (clickedCheckerMoves.length > 0) {
         state.selectedCheckerIndex = payload.index;
@@ -134,11 +132,14 @@ function onPlayerMessage(
         state.selectedCheckerIndex || -1,
         state.currentTeam
       );
-      const isCellInMoves = isIndexInMoves(payload.index, moves);
+      const isCellInMoves = isIndexInMoves(
+        payload.index,
+        moves.map(m => m.index)
+      );
 
       // Move the selected checker to the clicked cell
       if (state.selectedCheckerIndex && isCellInMoves) {
-        const { isJump, jumpIndex } = isMoveAJump(
+        const { isJump, jumpedCellIndex } = isMoveAJump(
           state.selectedCheckerIndex,
           payload.index,
           state.grid,
@@ -148,14 +149,14 @@ function onPlayerMessage(
         newGrid[payload.index] = state.currentTeam;
 
         if (isJump) {
-          newGrid[jumpIndex] = EMPTY_CELL;
+          newGrid[jumpedCellIndex] = EMPTY_CELL;
           state.grid = newGrid;
 
           const newMoves = getMovesForIndex(
             newGrid,
             payload.index,
             state.currentTeam
-          );
+          ).filter(m => m.isJump);
 
           // Player has no more moves available
           if (newMoves.length === 0) {

--- a/src/games/Checkers/hooks/useGameState.ts
+++ b/src/games/Checkers/hooks/useGameState.ts
@@ -102,12 +102,13 @@ function onPlayerMessage(
     // Player clicks their own checker
     if (
       state.gameStatus === GameStatus.PLAYING &&
-      newGrid[payload.index] === state.currentTeam
+      Math.floor(newGrid[payload.index]) === state.currentTeam
     ) {
+      console.log("A");
       const clickedCheckerMoves = getMovesForIndex(
         newGrid,
         payload.index,
-        state.currentTeam
+        newGrid[payload.index]
       );
 
       // Highlight selected checker if that checker has moves available
@@ -130,23 +131,25 @@ function onPlayerMessage(
       const moves = getMovesForIndex(
         newGrid,
         state.selectedCheckerIndex || -1,
-        state.currentTeam
+        newGrid[state.selectedCheckerIndex || -1]
       );
-      const isCellInMoves = isIndexInMoves(
-        payload.index,
-        moves.map(m => m.index)
-      );
+      const cellInMoves = moves.find(m => m.index === payload.index);
 
       // Move the selected checker to the clicked cell
-      if (state.selectedCheckerIndex && isCellInMoves) {
-        const { isJump, jumpedCellIndex } = isMoveAJump(
-          state.selectedCheckerIndex,
-          payload.index,
-          state.grid,
-          state.currentTeam
-        );
+      if (state.selectedCheckerIndex && cellInMoves !== undefined) {
+        const { isJump, jumpedCellIndex } = cellInMoves;
+
+        const py = indexToPoint(payload.index, GRID_COLUMNS).y;
+
+        // King the checker, if it has reached the y-edge of the board
+        // TODO Check 0 vs GRID_ROWS based on whether currentTeam is TEAM_0 or TEAM_1, perhaps
+        if (py === 0 || py === GRID_ROWS - 1) {
+          newGrid[payload.index] = state.currentTeam + 0.5;
+        } else {
+          newGrid[payload.index] = newGrid[state.selectedCheckerIndex || -1];
+        }
+
         newGrid[state.selectedCheckerIndex] = EMPTY_CELL;
-        newGrid[payload.index] = state.currentTeam;
 
         if (isJump) {
           newGrid[jumpedCellIndex] = EMPTY_CELL;

--- a/src/games/Checkers/models/Game.ts
+++ b/src/games/Checkers/models/Game.ts
@@ -1,0 +1,5 @@
+export interface Move {
+  index: number;
+  isJump: boolean;
+  jumpedCellIndex: number;
+}

--- a/src/games/TicTacToe/TicTacToe.tsx
+++ b/src/games/TicTacToe/TicTacToe.tsx
@@ -5,6 +5,8 @@ import TagFacesIcon from "@material-ui/icons/TagFaces";
 import Typography from "@material-ui/core/Typography";
 import { red, blue } from "@material-ui/core/colors";
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles";
+import RadioButtonUncheckedIcon from "@material-ui/icons/RadioButtonUnchecked";
+import CloseIcon from "@material-ui/icons/Close";
 import { GridBoard } from "components/GridBoard";
 import { pointToIndex } from "utils/GridUtil";
 import {
@@ -45,6 +47,17 @@ export const TicTacToe: FunctionComponent<TicTacToeProps> = ({
   state
 }) => {
   const classes = useStyles();
+
+  const gridBoxIcons = {
+    0: {
+      icon: RadioButtonUncheckedIcon,
+      color: red[500]
+    },
+    1: {
+      icon: CloseIcon,
+      color: blue[500]
+    }
+  };
 
   const handleBoxClick = (e: React.MouseEvent) => {
     e.persist();
@@ -97,6 +110,7 @@ export const TicTacToe: FunctionComponent<TicTacToeProps> = ({
           grid={state.grid}
           gridCellWidth={GRID_CELL_WIDTH}
           gridColumns={GRID_COLUMNS}
+          gridBoxIcons={gridBoxIcons}
           width={GRID_WIDTH}
           height={GRID_WIDTH}
           onClick={handleBoxClick}

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -1,4 +1,5 @@
 import { SvgIconProps } from "@material-ui/core";
+import { Move } from "games/Checkers/models/Game";
 
 export enum GameStatus {
   WIN = "WIN",
@@ -20,7 +21,7 @@ export interface GameState<T> {
   gameStatus: GameStatus;
   grid: Array<number>;
   selectedCheckerIndex?: number;
-  possibleMoves?: Array<number>;
+  possibleMoves?: Array<Move>;
 }
 
 export interface GameAction<T> {

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -1,3 +1,5 @@
+import { SvgIconProps } from "@material-ui/core";
+
 export enum GameStatus {
   WIN = "WIN",
   TIE = "TIE",
@@ -49,3 +51,10 @@ export interface GameWin {
 }
 
 export type allGameFlowDispatches = PlayerSelectIndex | PlayerConnect | GameWin;
+
+export type GridBoxIcons = {
+  [team: number]: {
+    icon: (props: SvgIconProps) => JSX.Element;
+    color: string;
+  };
+};

--- a/src/models/Game.ts
+++ b/src/models/Game.ts
@@ -19,6 +19,8 @@ export interface GameState<T> {
   gameActions: Array<GameAction<T>>;
   gameStatus: GameStatus;
   grid: Array<number>;
+  selectedCheckerIndex?: number;
+  possibleMoves?: Array<number>;
 }
 
 export interface GameAction<T> {

--- a/src/utils/GridUtil.ts
+++ b/src/utils/GridUtil.ts
@@ -1,4 +1,4 @@
-interface Point {
+export interface Point {
   x: number;
   y: number;
 }

--- a/src/utils/GridUtil.ts
+++ b/src/utils/GridUtil.ts
@@ -13,10 +13,3 @@ export const indexToPoint = (index: number, gridColumns: number): Point => {
 export const pointToIndex = (p: Point, gridColumns: number): number => {
   return p.y * gridColumns + p.x;
 };
-
-export const midPoint = (p1: Point, p2: Point): Point => {
-  return {
-    y: (p1.y + p2.y) / 2,
-    x: (p1.x + p2.x) / 2
-  };
-};

--- a/src/utils/GridUtil.ts
+++ b/src/utils/GridUtil.ts
@@ -39,7 +39,6 @@ export const getMovesForIndex = (
   const xOffset = 1;
   const yOffset = value >= TEAM_1 ? -1 : 1;
   const isKing = value % 1 !== 0;
-  console.log({ value, isKing });
   const basicMoves: Array<Point> = [
     { x: point.x - xOffset, y: point.y + yOffset },
     { x: point.x + xOffset, y: point.y + yOffset }

--- a/src/utils/GridUtil.ts
+++ b/src/utils/GridUtil.ts
@@ -13,3 +13,10 @@ export const indexToPoint = (index: number, gridColumns: number): Point => {
 export const pointToIndex = (p: Point, gridColumns: number): number => {
   return p.y * gridColumns + p.x;
 };
+
+export const midPoint = (p1: Point, p2: Point): Point => {
+  return {
+    y: (p1.y + p2.y) / 2,
+    x: (p1.x + p2.x) / 2
+  };
+};

--- a/src/utils/GridUtil.ts
+++ b/src/utils/GridUtil.ts
@@ -4,15 +4,11 @@ import {
   EMPTY_CELL,
   TEAM_1
 } from "games/Checkers/constants/GameSettings";
+import { Move } from "games/Checkers/models/Game";
 
 export interface Point {
   x: number;
   y: number;
-}
-
-interface Move {
-  index: number;
-  isJump: boolean;
 }
 
 export const indexToPoint = (index: number, gridColumns: number): Point => {
@@ -37,7 +33,7 @@ export const getMovesForIndex = (
   grid: Array<number>,
   index: number,
   value: number
-): Array<number> => {
+): Array<Move> => {
   const point = indexToPoint(index, GRID_COLUMNS);
   const team = Math.floor(value);
   const xOffset = 1;
@@ -78,12 +74,13 @@ export const getMovesForIndex = (
     []
   );
   return [...basicMoves, ...kingMoves, ...filteredJumps].reduce(
-    (m: Array<number>, p: Point) => {
+    (m: Array<Move>, p: Point) => {
       const i = pointToIndex(p, GRID_COLUMNS);
       if (!isPointOutOfBounds(p)) {
         // Cell is empty. Move is good.
         if (grid[i] === EMPTY_CELL) {
-          m.push(i);
+          const { isJump, jumpedCellIndex } = isMoveAJump(index, i, grid, team);
+          m.push({ index: i, isJump, jumpedCellIndex });
           return m;
         }
       }
@@ -109,19 +106,13 @@ export const isMoveAJump = (
   const pa = indexToPoint(ia, GRID_COLUMNS);
   const pb = indexToPoint(ib, GRID_COLUMNS);
   const pz = { x: (pa.x + pb.x) / 2, y: (pa.y + pb.y) / 2 };
-  const jumpIndex = pointToIndex(pz, GRID_COLUMNS);
+  const jumpedCellIndex = pointToIndex(pz, GRID_COLUMNS);
   const isDistanceAJump = Math.abs(pa.x - pb.x) === 2;
   const isJumpedIndexEnemyCell =
-    grid[jumpIndex] !== EMPTY_CELL && grid[jumpIndex] !== team;
-  console.log(
-    "!@#$%^&   pa, pb, isJumpedEnemyCell, team",
-    pa,
-    pb,
-    isJumpedIndexEnemyCell,
-    team
-  );
+    grid[jumpedCellIndex] !== EMPTY_CELL && grid[jumpedCellIndex] !== team;
+
   return {
     isJump: isDistanceAJump && isJumpedIndexEnemyCell,
-    jumpIndex
+    jumpedCellIndex
   };
 };

--- a/src/utils/GridUtil.ts
+++ b/src/utils/GridUtil.ts
@@ -39,6 +39,7 @@ export const getMovesForIndex = (
   const xOffset = 1;
   const yOffset = value >= TEAM_1 ? -1 : 1;
   const isKing = value % 1 !== 0;
+  console.log({ value, isKing });
   const basicMoves: Array<Point> = [
     { x: point.x - xOffset, y: point.y + yOffset },
     { x: point.x + xOffset, y: point.y + yOffset }

--- a/src/utils/GridUtil.ts
+++ b/src/utils/GridUtil.ts
@@ -1,6 +1,24 @@
+import {
+  GRID_COLUMNS,
+  GRID_ROWS,
+  EMPTY_CELL,
+  TEAM_0,
+  TEAM_1
+} from "games/Checkers/constants/GameSettings";
+
 export interface Point {
   x: number;
   y: number;
+}
+
+enum Direction {
+  up = "up",
+  down = "down"
+}
+
+interface Move {
+  index: number;
+  isJump: boolean;
 }
 
 export const indexToPoint = (index: number, gridColumns: number): Point => {
@@ -10,6 +28,95 @@ export const indexToPoint = (index: number, gridColumns: number): Point => {
   };
 };
 
+export const isIndexInMoves = (index: number, moves: Array<Move>): boolean =>
+  moves.findIndex(m => m.index === index) !== -1;
+
 export const pointToIndex = (p: Point, gridColumns: number): number => {
   return p.y * gridColumns + p.x;
+};
+
+const isYCoordinateOutOfBounds = (yCoordinate: number, team: number) =>
+  team === TEAM_0 ? yCoordinate >= GRID_ROWS : yCoordinate < 0;
+
+export const getMovesForIndex = (
+  grid: Array<number>,
+  index: number,
+  team: number
+) => {
+  const moves: Array<Move> = [];
+
+  if (index >= 0) {
+    const p0 = indexToPoint(index, GRID_COLUMNS);
+    const xOffset = 1;
+    const yOffset = team === TEAM_1 ? -1 : 1;
+
+    const leftMove: Point = { x: p0.x - xOffset, y: p0.y + yOffset };
+    const leftMoveIndex = pointToIndex(leftMove, GRID_COLUMNS);
+    const rightMove: Point = { x: p0.x + xOffset, y: p0.y + yOffset };
+    const rightMoveIndex = pointToIndex(rightMove, GRID_COLUMNS);
+
+    if (
+      leftMove.x >= 0 &&
+      !isYCoordinateOutOfBounds(leftMove.y, team) &&
+      grid[leftMoveIndex] === EMPTY_CELL
+    ) {
+      const isJump = isMoveAJump(leftMoveIndex, index).isJump;
+      moves.push({ index: leftMoveIndex, isJump });
+    } else if (
+      grid[leftMoveIndex] !== EMPTY_CELL &&
+      grid[leftMoveIndex] !== team
+    ) {
+      const leftJumpMove: Point = {
+        x: leftMove.x - xOffset,
+        y: leftMove.y + yOffset
+      };
+      const leftJumpMoveIndex = pointToIndex(leftJumpMove, GRID_COLUMNS);
+      if (
+        leftJumpMove.x >= 0 &&
+        !isYCoordinateOutOfBounds(leftJumpMove.y, team) &&
+        grid[leftJumpMoveIndex] === EMPTY_CELL
+      ) {
+        const isJump = isMoveAJump(leftJumpMoveIndex, index).isJump;
+        moves.push({ index: leftJumpMoveIndex, isJump });
+      }
+    }
+
+    if (
+      rightMove.x < GRID_COLUMNS &&
+      !isYCoordinateOutOfBounds(rightMove.y, team) &&
+      grid[rightMoveIndex] === EMPTY_CELL
+    ) {
+      const isJump = isMoveAJump(rightMoveIndex, index).isJump;
+      moves.push({ index: rightMoveIndex, isJump });
+    } else if (
+      grid[rightMoveIndex] !== EMPTY_CELL &&
+      grid[rightMoveIndex] !== team
+    ) {
+      const rightJumpMove: Point = {
+        x: rightMove.x + xOffset,
+        y: rightMove.y + yOffset
+      };
+      const rightJumpMoveIndex = pointToIndex(rightJumpMove, GRID_COLUMNS);
+      if (
+        rightJumpMove.x < GRID_COLUMNS &&
+        !isYCoordinateOutOfBounds(rightJumpMove.y, team) &&
+        grid[rightJumpMoveIndex] === EMPTY_CELL
+      ) {
+        const isJump = isMoveAJump(rightJumpMoveIndex, index).isJump;
+        moves.push({ index: rightJumpMoveIndex, isJump });
+      }
+    }
+  }
+
+  return moves;
+};
+
+export const isMoveAJump = (ia: number, ib: number) => {
+  const pa = indexToPoint(ia, GRID_COLUMNS);
+  const pb = indexToPoint(ib, GRID_COLUMNS);
+  const pz = { x: (pa.x + pb.x) / 2, y: (pa.y + pb.y) / 2 };
+  return {
+    isJump: Math.abs(pa.x - pb.x) === 2,
+    jumpIndex: pointToIndex(pz, GRID_COLUMNS)
+  };
 };


### PR DESCRIPTION
Adds basic checkers game support

**Notes**
- Players can move across the board, capture enemy checkers, and can king their checkers
- The winner is determined by a team having 0 checkers left
- Scoreboard currently works like TicTacToe -- we show the score at the game level. Might be worth changing to show taken checker counts... thoughts?

**TODO**
- Further develop win conditions to include enemy team not being able to make a move for a turn (rare, but happens from time to time)
